### PR TITLE
add information about remote Artifact Registry repository for ghcr.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ The whitelisted scripts are taken from:
 
 ## Deployment
 
+The instance validator container image is available on GitHub Container Registry (ghcr.io).
+To use is in a CloudRun service, you need to create a remote Artifact Registry repository, which points to ghcr.io.
+Refer to [this document](https://cloud.google.com/artifact-registry/docs/repositories/remote-repo) to create a remote Artifact Registry repository.
+
 The application can be deployed using the Terraform module in the [`terraform`](./terraform/) directory.
 
 You can use this module in your Terraform configuration by adding the following module block:
@@ -22,8 +26,8 @@ You can use this module in your Terraform configuration by adding the following 
 module "validator" {
   source = "github.com/castai/gcp-node-validator/terraform"
 
-  name_prefix     = "my-validator"
-  validator_image = "ghcr.io/castai/node-validator:v0.1.0-8-gdc83ed3"
+  name_prefix     = "castai-validator"
+  validator_image = "<ghcr-remote-repository>/castai/node-validator:v0.1.2"
   project         = "<gcp-project>"
   region          = "<gcp-region>"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,4 @@
+output "whitelist_gcs_bucket_name" {
+  description = "The name of the GCS bucket to store the script whitelists."
+  value       = google_storage_bucket.main.name
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -36,6 +36,12 @@ resource "google_project_iam_member" "runinvoker" {
   member  = "serviceAccount:${google_service_account.main.email}"
 }
 
+resource "google_project_iam_member" "artifactregistry_reader" {
+  project = data.google_project.project.id
+  role    = "roles/artifactregistry.reader"
+  member  = "serviceAccount:${google_service_account.main.email}"
+}
+
 resource "google_project_iam_custom_role" "instance_validator" {
   role_id     = "${var.name_prefix}CastInstanceValidator"
   title       = "CAST AI Instance Validator"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -30,7 +30,7 @@ variable "alert_severity" {
 }
 
 variable "delete_mode" {
-  description = "Whether to delete invalid instances."
+  description = "Whether to delete invalid instances"
   type        = bool
   default     = false
 }


### PR DESCRIPTION
It's not possible to use images from `ghcr.io` directly in CloudRun functions, you need to use an intermediate Artifact Registry remote repository.

This PR adds information about this to the README.md and grants the CloudRun permissions to access Artifact Registry to fetch the image.

Also adding `whitelist_gcs_bucket_name` output, might be useful somebody want to manage the whitelisted scripts also from Terraform.